### PR TITLE
Update de la fonction SARAH.askme()

### DIFF
--- a/script/manager/sarah.js
+++ b/script/manager/sarah.js
@@ -321,7 +321,7 @@ var askme = function(tts, grammar, timeout, callback){
       } else {
         SARAH.askme(tts, grammar, -timeout, callback);
       }
-  }, Math.abs(timeout) || 8000);
+  }, Math.abs(timeout) || 16000);
 }
 
 var answerme = function(req, res, next){

--- a/script/manager/sarah.js
+++ b/script/manager/sarah.js
@@ -319,9 +319,9 @@ var askme = function(tts, grammar, timeout, callback){
       if (timeout <= 0){
         callback(false, end);
       } else {
-        SARAH.askme(tts, grammar, 0, callback);
+        SARAH.askme(tts, grammar, -timeout, callback);
       }
-  }, timeout || 16000);
+  }, Math.abs(timeout) || 8000);
 }
 
 var answerme = function(req, res, next){


### PR DESCRIPTION
La doc (wiki) indique pour la fonction SARAH.askme():
"S'il n'y a aucune réponse après timeout x 2, ou 8 secondes, alors la fonction de callback est appelée avec false en paramètre"

Mais en réalité, il y avait une question avec timeout x 1 puis répétition de la question avec un timeout de 16 secondes.

La modif de code permet:
- si timeout est positif, que Sarah pose la question deux fois avec le timeout indiqué
- si timeout est négatif, que Sarah pose la question UNE fois avec le timeout indiqué
- si timeout vaut zéro, Sarah pose la question UNE fois avec un timeout par défaut de 8 secondes

A part le délai "par défaut" qui revient à 8 secondes comme décrit dans la doc wiki, ce changement ne devrait avoir aucun impact sur les différents plugins déjà publiés.
